### PR TITLE
heap: Don't notify MemoryReducer when merging shared space from client

### DIFF
--- a/src/heap/heap.h
+++ b/src/heap/heap.h
@@ -413,9 +413,17 @@ class Heap final {
 
   void NotifyBootstrapComplete();
 
-  void NotifyOldGenerationExpansion(LocalHeap* local_heap,
-                                    AllocationSpace space,
-                                    MutablePageMetadata* chunk);
+  enum class OldGenerationExpansionNotificationOrigin {
+    // Specifies that the notification is coming from the client heap.
+    kFromClientHeap,
+    // Specifies that the notification is done within the same heap.
+    kFromSameHeap,
+  };
+
+  void NotifyOldGenerationExpansion(
+      LocalHeap* local_heap, AllocationSpace space, MutablePageMetadata* chunk,
+      OldGenerationExpansionNotificationOrigin =
+          OldGenerationExpansionNotificationOrigin::kFromSameHeap);
 
   inline Address* NewSpaceAllocationTopAddress();
   inline Address* NewSpaceAllocationLimitAddress();

--- a/src/heap/paged-spaces.h
+++ b/src/heap/paged-spaces.h
@@ -376,16 +376,28 @@ class V8_EXPORT_PRIVATE PagedSpace : public PagedSpaceBase {
 
 class V8_EXPORT_PRIVATE CompactionSpace final : public PagedSpace {
  public:
+  // Specifies to which heap the compaction space should be merged.
+  enum class DestinationHeap {
+    // Should be merged to the same heap.
+    kSameHeap,
+    // Should be merged to the main isolate shared space.
+    kSharedSpaceHeap
+  };
+
   CompactionSpace(Heap* heap, AllocationSpace id, Executability executable,
-                  CompactionSpaceKind compaction_space_kind)
+                  CompactionSpaceKind compaction_space_kind,
+                  DestinationHeap destination_heap)
       : PagedSpace(heap, id, executable, FreeList::CreateFreeList(),
-                   compaction_space_kind) {
+                   compaction_space_kind),
+        destination_heap_(destination_heap) {
     DCHECK(is_compaction_space());
   }
 
   const std::vector<PageMetadata*>& GetNewPages() { return new_pages_; }
 
   void RefillFreeList() final;
+
+  DestinationHeap destination_heap() const { return destination_heap_; }
 
  protected:
   void NotifyNewPage(PageMetadata* page) final;
@@ -395,6 +407,7 @@ class V8_EXPORT_PRIVATE CompactionSpace final : public PagedSpace {
   // Pages that were allocated in this local space and need to be merged
   // to the main space.
   std::vector<PageMetadata*> new_pages_;
+  const DestinationHeap destination_heap_;
 };
 
 // A collection of |CompactionSpace|s used by a single compaction task.

--- a/test/unittests/heap/spaces-unittest.cc
+++ b/test/unittests/heap/spaces-unittest.cc
@@ -55,7 +55,8 @@ TEST_F(SpacesTest, CompactionSpaceMerge) {
 
   CompactionSpace* compaction_space =
       new CompactionSpace(heap, OLD_SPACE, NOT_EXECUTABLE,
-                          CompactionSpaceKind::kCompactionSpaceForMarkCompact);
+                          CompactionSpaceKind::kCompactionSpaceForMarkCompact,
+                          CompactionSpace::DestinationHeap::kSameHeap);
   MainAllocator allocator(heap, compaction_space, MainAllocator::kInGC);
   EXPECT_TRUE(compaction_space != nullptr);
 


### PR DESCRIPTION
When the compaction space from the client isolate gets merged into the shared space of the main isolate, there is a race, when we notify the main isolate's MemoryReducer about possible new garbage. Don't do this when notifying across heaps.

Bug: 360817486
Change-Id: I491e39ca31080ff6360e5a98ebff079eab9bfa4b
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5823542
Reviewed-by: Omer Katz <omerkatz@chromium.org>
Commit-Queue: Anton Bikineev <bikineev@chromium.org>
Cr-Commit-Position: refs/heads/main@{#95905}